### PR TITLE
Añadir clase Configuration para gestionar migraciones

### DIFF
--- a/Proyecto_ExpedicionOxigeno/Migrations/Configuration.cs
+++ b/Proyecto_ExpedicionOxigeno/Migrations/Configuration.cs
@@ -1,0 +1,23 @@
+﻿namespace Proyecto_ExpedicionOxigeno.Migrations
+{
+    using System;
+    using System.Data.Entity;
+    using System.Data.Entity.Migrations;
+    using System.Linq;
+
+    internal sealed class Configuration : DbMigrationsConfiguration<Proyecto_ExpedicionOxigeno.Models.ApplicationDbContext>
+    {
+        public Configuration()
+        {
+            AutomaticMigrationsEnabled = false;
+        }
+
+        protected override void Seed(Proyecto_ExpedicionOxigeno.Models.ApplicationDbContext context)
+        {
+            //  This method will be called after migrating to the latest version.
+
+            //  You can use the DbSet<T>.AddOrUpdate() helper extension method
+            //  to avoid creating duplicate seed data.
+        }
+    }
+}


### PR DESCRIPTION
Se ha añadido la clase `Configuration` en `Configuration.cs` dentro del espacio de nombres `Proyecto_ExpedicionOxigeno.Migrations`. Esta clase hereda de `DbMigrationsConfiguration<Proyecto_ExpedicionOxigeno.Models.ApplicationDbContext>` y configura las migraciones de la base de datos.

El constructor establece `AutomaticMigrationsEnabled` como `false`, deshabilitando las migraciones automáticas. Además, se ha implementado el método `Seed`, actualmente vacío, que permite inicializar datos tras aplicar las migraciones.